### PR TITLE
Prevent double-click from scoring answers twice

### DIFF
--- a/src/components/TestApp/TestButton.tsx
+++ b/src/components/TestApp/TestButton.tsx
@@ -2,9 +2,21 @@ import { cn } from "@/lib/utils";
 import { Button, type ButtonProps } from "@components/ui/button";
 
 const TestButton = (props: ButtonProps) => {
-  const { className, ...restProps } = props;
+  const { className, onClick, ...restProps } = props;
 
-  return <Button variant="outline" className={cn(className)} {...restProps} />;
+  return (
+    <Button
+      variant="outline"
+      className={cn(className)}
+      {...restProps}
+      onClick={(e) => {
+        // ponytail: ignore 2nd+ click of a double/triple-click (detail > 1).
+        // Ceiling: won't catch two separate single clicks; upgrade = question-scoped lock.
+        if (e.detail > 1) return;
+        onClick?.(e);
+      }}
+    />
+  );
 };
 
 export default TestButton;


### PR DESCRIPTION
## Summary
- Ignore the 2nd+ click of a double/triple-click on `TestButton` (`event.detail > 1`), so one physical double-click cannot score the same question twice.
- Scoped to answer buttons only; selector / start CTAs use `Button` and are unchanged.